### PR TITLE
Update README to include Google subset information

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,16 @@ WebFontConfig = {
 };
 ```
 
+If you need to specify character subsets other than the default (e.g.: greek script in addition to latin), you must append the subset string to the requested family string after a colon. The subset string should follow the [Google documentation](https://developers.google.com/fonts/docs/getting_started#Subsets) (subset names separated by commas):
+
+```javascript
+WebFontConfig = {
+  google: {
+    families: ['Open Sans Condensed:300,700:latin,greek']
+  }
+};
+```
+
 You can also supply the `text` parameter to perform character subsetting:
 
 ```javascript


### PR DESCRIPTION
It may otherwise be unclear how to specify subsets since this is not the style used by the Google documentation, which includes all the subsets together in a query string variable separate from the `families`. The rest of the documentation here (notably the docs for`text`) implies that the correct syntax would be to use a `subset` keyword like this, which does not work.

``` javascript
WebFontConfig = {
  google: {
    families: ['Open Sans Condensed:300,700'],
    subset: 'latin,greek'
  }
};
```
